### PR TITLE
Get env vars directly from MySQL

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -38,11 +38,6 @@ services:
     mountPath: /var/lib/mysql
     sizeGB: 20
   envVars:
-  - fromGroup: mysql-wordpress
-
-envVarGroups:
-- name: mysql-wordpress
-  envVars:
   - key: MYSQL_DATABASE
     value: mysql
   - key: MYSQL_USER

--- a/render.yaml
+++ b/render.yaml
@@ -14,11 +14,20 @@ services:
       type: pserv
       property: host
   - key: WORDPRESS_DB_NAME
-    value: mysql
+    fromService:
+      name: mysql-wordpress
+      type: pserv
+      envVarKey: MYSQL_DATABASE
   - key: WORDPRESS_DB_USER
-    value: mysql
+    fromService:
+      name: mysql-wordpress
+      type: pserv
+      envVarKey: MYSQL_USER
   - key: WORDPRESS_DB_PASSWORD
-    value: mysql
+    fromService:
+      name: mysql-wordpress
+      type: pserv
+      envVarKey: MYSQL_PASSWORD
 - type: pserv
   name: mysql-wordpress
   repo: https://github.com/render-examples/mysql.git


### PR DESCRIPTION
render.yaml currently does not allow pulling specific env vars from env groups and renaming them. This PR is a workaround.