### PR TITLE
Adds a one-click 'Deploy to Render' button to the repos's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ This is a template repository for running [Wordpress](https://wordpress.org) on 
 
 ## Deployment
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+
 See https://render.com/docs/deploy-wordpress.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This is a template repository for running [Wordpress](https://wordpress.org) on 
 
 ## Deployment
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/wordpress)
 
 See https://render.com/docs/deploy-wordpress.


### PR DESCRIPTION
In coordination with updating the Render docs for deploying Wordpress to Render, this PR adds a one-click 'Deploy to Render' button to the README.

Signed-off-by: zach wick <zach@render.com>