### PR TITLE
Update Dockerfile to use latest WP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # You can change this to a different version of Wordpress available at
 # https://hub.docker.com/_/wordpress
-FROM wordpress:5.3.2-apache
+FROM wordpress:latest
 
 RUN apt-get update && apt-get install -y magic-wormhole
 


### PR DESCRIPTION
The pinned version in our current example Dockerfile is not deploying successfully. This PR ensures we use the latest version available by default.